### PR TITLE
Updated readme with new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# github-hooks
-Our hooks for github
+# HooksHub
+Our Hub of Hooks
 
-[![Build Status](https://travis-ci.org/gisce/github-hooks.svg?branch=master)](https://travis-ci.org/gisce/github-hooks)
-[![Coverage Status](https://coveralls.io/repos/github/gisce/github-hooks/badge.svg?branch=master)](https://coveralls.io/github/gisce/github-hooks?branch=master)
+[![Build Status](https://travis-ci.org/gisce/hookshub.svg?branch=master)](https://travis-ci.org/gisce/hookshub)
+[![Coverage Status](https://coveralls.io/repos/github/gisce/hookshub/badge.svg?branch=master)](https://coveralls.io/github/gisce/hookshub?branch=master)
 
 ## Installation
 


### PR DESCRIPTION
_github-hooks ->  hookshub_
- Build Status 
- Coveralls Status

Updated coveralls enable for this repository
