### PR TITLE
Fix errors on powerp-docs merges

### DIFF
--- a/hookshub/hooks/github_hooks/pull_request-powerp-docs_endPR.py
+++ b/hookshub/hooks/github_hooks/pull_request-powerp-docs_endPR.py
@@ -2,29 +2,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
-from json import loads, dumps
-from os.path import join
+from json import loads
 from hookshub.hooks.github import GitHubUtil as Util
-from subprocess import Popen, PIPE
 
 import sys
-import tempfile
-import shutil
+from os import system as call
 
 # This script is called whenever a PR is closed. Let it be the cases:
 # - A PR has been merged (action= 'closed', merged= 'True')
 # - A PR has been closed (action= 'closed', merged= 'False')
-
-
-class TempDir(object):
-    def __init__(self):
-        self.dir = tempfile.mkdtemp()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        shutil.rmtree(self.dir)
 
 
 # Carrega dels arguments. Conte els detalls del event
@@ -38,7 +24,6 @@ def arguments():
 payload, event = arguments()
 
 output = ''
-http_url = "https://api.github.com"
 
 action = payload['action']
 if action != Util.actions['ACT_CLOSED']:
@@ -48,109 +33,22 @@ if action != Util.actions['ACT_CLOSED']:
     print (output)
     exit(0)
 
-pr_num = payload['number']
-if not pr_num:
-    output = 'Failed to get number (Is the PR ready?)'
-    print (output)
-    exit(-1)
-
-url = payload['ssh_url'] or payload['http_url']
-if not url:
-    output = 'Failed to get URL (was it in payload?)'
-    print (output)
-    exit(-1)
-
-closed = payload['closed']
 repo_name = payload['repo_name']
-repo_full_name = payload['repo_full_name']
 branch_name = payload['branch_name']
 output += ('Rebut event de <{}> |'.format(event))
-
-# Get from env_vars
-token = payload['token']
-port = payload['port']
 
 
 util_docs_path = '{0}/{1}/powerp_{2}'.format(
     payload['vhost_path'], repo_name, branch_name
 )
 
-docs_path = '{0}/{1}/master'.format(
-    payload['vhost_path'], repo_name
-)
-
-ca_docs_path = '{0}/ca/'.format(
-    docs_path
-)
-es_docs_path = '{0}/es/'.format(
-    docs_path
-)
-
 output = 'Removing data on: {} ...'.format(util_docs_path)
 command = 'rm -r {}'.format(util_docs_path)
 
-delete = Popen(
-    command.split(), stdout=PIPE, stderr=PIPE
-)
-out, err = delete.communicate()
-
-if delete.returncode != 0:
-    output += 'Failed to remove files! {}|'.format(out)
-    output += 'Error on "rm -r": {}'.format(err)
+if call(command) != 0:
+    output += 'Failed to remove files! |'
     print(output)
     exit(-1)
 
 output += 'Removed!|'
-
-# Es pot fer despres de respondre:
-
-# Si s'ha tencat sense mergejar, no actualitzem el build
-#   Altrament fem build de master abans de borrar la PR
-if not closed:
-    with TempDir() as temp:
-        output += ('Creat Directori temporal: {} |'.format(temp.dir))
-
-        # Primer clonem el repositori
-        out, code, err = Util.clone_on_dir(temp.dir, repo_name, url)
-        output += out
-        if code != 0:
-            output += 'Clonant el repository desde http'
-            url = payload['http_url']
-            out, code, err2 = Util.clone_on_dir(temp.dir, repo_name, url)
-            if code != 0:
-                # Could not clone >< => ABORT
-                sys.stderr.write(
-                    '| Failed to get repository {0};\n;{1}|'.format(err, err2)
-                )
-                print(output)
-                exit(-1)
-        output += ' OK |'
-        # Accedim al directori del clone utilitzant el nom del repositori
-
-        clone_dir = join(temp.dir, repo_name)
-
-        # Crear Virtualenv en el directori temporal
-        Util.create_virtualenv(temp.dir, branch_name)
-
-        # Instalem dependencies
-
-        output += Util.pip_requirements(clone_dir)
-
-        # Fem build al directori on tenim la pagina des del directori del clone
-        #   Build en català
-        out, target_build_path = (
-            Util.docs_build(clone_dir, ca_docs_path, None, True)
-        )
-        if not target_build_path:
-            output = '{} FAILED!\n{} |'.format(output, out)
-        output += '{} |'.format(out)
-
-        #   Build en castellà
-        out, target_build_path = (
-            Util.docs_build(clone_dir, es_docs_path, 'mkdocs_es.yml', True)
-        )
-        if not target_build_path:
-            output = '{} FAILED!\n{} |'.format(output, out)
-        output += '{} |'.format(out)
-
 print(output)

--- a/hookshub/hooks/github_hooks/push-powerp-docs.py
+++ b/hookshub/hooks/github_hooks/push-powerp-docs.py
@@ -9,7 +9,6 @@ from hookshub.hooks.github import GitHubUtil as Util
 import sys
 import tempfile
 import shutil
-import os
 
 
 class TempDir(object):
@@ -175,5 +174,5 @@ with TempDir() as temp:
             output += 'Failed to write comment. ' \
                       'Server responded with {} |'.format(post_code)
             output += dumps(loads(post_text))
-    
+
 print(output)

--- a/hookshub/hooks/github_hooks/push-powerp-docs.py
+++ b/hookshub/hooks/github_hooks/push-powerp-docs.py
@@ -139,53 +139,41 @@ with TempDir() as temp:
         from distutils.dir_util import copy_tree as copy
         copy(landing_dir, util_docs_path)
 
-    output += ' Writting comment on PR ...'
+    if docs_dir != 'master':
+        output += ' Writting comment on PR ...'
 
-    # Construim el comentari:
-    #   Docs path te /var/www/domain/URI
-    base_url = util_docs_path.split('/', 3)[3]   # Kick out /var/www/
-    if port in ['80', '443']:
-        res_url = '{0}/'.format(base_url)
-    else:
-        res_url = '{0}:{1}/'.format(base_url, port)
-    comment = 'Documentation build URL:\nhttp://{}\n'.format(res_url)
+        # Construim el comentari:
+        #   Docs path te /var/www/domain/URI
+        base_url = util_docs_path.split('/', 3)[3]   # Kick out /var/www/
+        if port in ['80', '443']:
+            res_url = '{0}/'.format(base_url)
+        else:
+            res_url = '{0}:{1}/'.format(base_url, port)
+        comment = 'Documentation build URL:\nhttp://{}\n'.format(res_url)
 
-    # Necessitem agafar totes les pull request per trobar la nostra
+        # Necessitem agafar totes les pull request per trobar la nostra
 
-    my_pr, out = Util.get_pr(token, repo_full_name, branch_name)
-    output += out
+        my_pr, out = Util.get_pr(token, repo_full_name, branch_name)
+        output += out
 
-    # If getting pr fails, we ommit comment post
-    if my_pr <= 0:
-        print(output)
-        exit(0)
+        # If getting pr fails, we ommit comment post
+        if my_pr <= 0:
+            print(output)
+            exit(0)
 
-    # Postejem el comentari
+        # Postejem el comentari
 
-    post_code, post_text = Util.post_comment_pr(
-        token, repo_full_name, my_pr['number'], comment
-    )
+        post_code, post_text = Util.post_comment_pr(
+            token, repo_full_name, my_pr['number'], comment
+        )
 
-    if post_code == 201:
-        output += ' OK|'
-    elif post_code == 0:
-        output += ' Something went wrong |'
-    else:
-        output += 'Failed to write comment. ' \
-                  'Server responded with {} |'.format(post_code)
-        output += dumps(loads(post_text))
-
-    # if virtenv:
-    #     output += 'Deactivate virtualenv ...'
-    #     command = 'deactivate'
-    #     deact = Popen(
-    #         command, cwd=clone_dir, stdout=PIPE, stderr=PIPE
-    #     )
-    #     out, err = deact.communicate()
-    #     if deact.returncode != 0:
-    #         output += 'FAILED TO DEACTIVATE: {0}::{1}'.format(out, err)
-    #         print(output)
-    #         exit(-1)
-    #     output += 'OK |'
-
+        if post_code == 201:
+            output += ' OK|'
+        elif post_code == 0:
+            output += ' Something went wrong |'
+        else:
+            output += 'Failed to write comment. ' \
+                      'Server responded with {} |'.format(post_code)
+            output += dumps(loads(post_text))
+    
 print(output)


### PR DESCRIPTION
In push event:
- [X] Add if to skip posting a comment if branch is master
- [X] Remove commented code to deactivate virtualenv no longer used
- [x] ~Add exception for branch does not exist (should return 400 instead of 500)~ 
  - Ignores try-except...

In PR end event:
- [x] Remove docs build code
  - Not needed because on merge there's a push to master
  - Can outcome in aliasing master's files